### PR TITLE
Use systemd services if available instead of cron jobs

### DIFF
--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,1 +1,2 @@
 --relative
+--no-parameter_documentation-check

--- a/README.md
+++ b/README.md
@@ -23,14 +23,12 @@ Optionally put the following variables into hiera and adjust to your requirement
   sysstat::compressafter: 31
   sysstat::sadc_options: "-S DISK"
   sysstat::zip: "bzip2"
-  sysstat::installpkg: 'yes'
   sysstat::generate_summary: 'yes'
   sysstat::disable: 'no'
-
 ```
-Setting the `disable` setting to `'yes'` will remove the cron entries, but leave the package installed.
+Setting the `disable` setting to `'yes'` will remove the cron entries or disable and stop sysstat-collect.timer, but will leave the package installed.
 
-The `generate_summary` option determines whether or not sa2 is active (often called daily summary).
+The `generate_summary` option determines whether sa2 or sysstat-summary.timer (often called daily summary) will be active or not.
 
 ## Limitations
 The sa1 invocation duration needs to a minute or greater.  If sub minute sample sizes are required, set the `sa1_samples` parameter to greater than 1 to take multiple samples per invocation of sa1.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,7 +27,6 @@ class sysstat (
   Integer   $compressafter    = 31,
   String    $sadc_options     = '-S DISK',
   String    $zip              = 'bzip2',
-  String    $installpkg       = 'yes',
   String    $generate_summary = 'yes',
   String    $disable          = 'no',
   Integer   $sa2_delay_range  = 0,
@@ -36,14 +35,20 @@ class sysstat (
   # Convert duration to seconds
   $sa1_duration_seconds = $sa1_duration * 60 - 1
 
-  if $disable == 'yes' {
-    $file_ensure = 'absent'
-    $cron_ensure = 'absent'
-    $pkg_ensure = 'absent'
+  if $generate_summary == 'yes' and $disable != 'yes' {
+    $svc_summary_ensure = true
   } else {
-    $file_ensure = 'file'
-    $cron_ensure = 'present'
-    $pkg_ensure = 'latest'
+    $svc_summary_ensure = false
+  }
+
+  if $disable == 'yes' {
+    $file_ensure        = 'absent'
+    $cron_ensure        = 'absent'
+    $svc_collect_ensure = false
+  } else {
+    $file_ensure        = 'file'
+    $cron_ensure        = 'present'
+    $svc_collect_ensure = true
   }
 
   case $facts['os']['family'] {
@@ -88,27 +93,88 @@ class sysstat (
       }
     }
     default: {
-      file { $cron_path:
-        ensure  => $file_ensure,
-        content => epp('sysstat/crontab.epp', {
-            sa1_path             => $sa1_path,
-            sa1_options          => $sa1_options,
-            sa1_interval         => $sa1_interval,
-            sa1_duration         => $sa1_duration,
-            sa1_duration_seconds => $sa1_duration_seconds,
-            sa1_samples          => $sa1_samples,
-            sa2_path             => $sa2_path,
-            sa2_options          => $sa2_options,
-            sa2_minute           => $sa2_minute,
-            sa2_hour             => $sa2_hour,
-            generate_summary     => $generate_summary,
-        }),
+      package { $package:
+        ensure => 'installed',
       }
 
-      if $installpkg == 'yes' {
-        package { $package:
-          ensure => installed,
-          before => File[$conf_path],
+      if ($facts['os']['family'] == 'RedHat' and Float($facts['os']['release']['major']) >= 8.0)
+      or ($facts['os']['distro']['id'] == 'Debian' and Float($facts['os']['release']['major']) >= 11.0 )
+      or ($facts['os']['distro']['id'] == 'Ubuntu' and Float($facts['os']['release']['major']) >= 22.04) {
+        file { [
+            '/etc/systemd/system/sysstat-summary.timer.d',
+            '/etc/systemd/system/sysstat-collect.timer.d',
+            '/etc/systemd/system/sysstat-summary.service.d',
+            '/etc/systemd/system/sysstat-collect.service.d',
+          ]:
+            ensure => 'directory',
+            mode   => '0755',
+            group  => 'root',
+            owner  => 'root',
+        }
+        exec { 'systemctl daemon-reload':
+          command     => 'systemctl daemon-reload',
+          path        => ['/bin','/usr/bin','/sbin','/usr/sbin'],
+          refreshonly => true,
+          subscribe   => Package[$package],
+        }
+        file { '/etc/systemd/system/sysstat-collect.timer.d/override.conf':
+          ensure  => file,
+          content => epp('sysstat/sysstat_collect.timer.override.epp', {
+              sa1_interval => $sa1_interval,
+          }),
+          notify  => Exec['systemctl daemon-reload'],
+        }
+        file { '/etc/systemd/system/sysstat-summary.timer.d/override.conf':
+          ensure  => file,
+          content => epp('sysstat/sysstat_summary.timer.override.epp', {
+              sa2_minute => $sa2_minute,
+              sa2_hour   => $sa2_hour,
+          }),
+          notify  => Exec['systemctl daemon-reload'],
+        }
+        file { '/etc/systemd/system/sysstat-collect.service.d/override.conf':
+          ensure  => file,
+          content => epp('sysstat/sysstat_collect.service.override.epp', {
+              sa1_path             => $sa1_path,
+              sa1_duration_seconds => $sa1_duration_seconds,
+              sa1_samples          => $sa1_samples,
+          }),
+          notify  => Exec['systemctl daemon-reload'],
+        }
+        file { '/etc/systemd/system/sysstat-summary.service.d/override.conf':
+          ensure  => file,
+          content => epp('sysstat/sysstat_summary.service.override.epp', {
+              sa2_path    => $sa2_path,
+              sa2_options => $sa2_options,
+          }),
+          notify  => Exec['systemctl daemon-reload'],
+        }
+        service { 'sysstat-collect.timer':
+          ensure  => $svc_collect_ensure,
+          enable  => $svc_collect_ensure,
+          require => Package[$package],
+        }
+        service { 'sysstat-summary.timer':
+          ensure  => $svc_summary_ensure,
+          enable  => $svc_summary_ensure,
+          require => Package[$package],
+        }
+      } else {
+        file { $cron_path:
+          ensure  => $file_ensure,
+          content => epp('sysstat/crontab.epp', {
+              sa1_path             => $sa1_path,
+              sa1_options          => $sa1_options,
+              sa1_interval         => $sa1_interval,
+              sa1_duration         => $sa1_duration,
+              sa1_duration_seconds => $sa1_duration_seconds,
+              sa1_samples          => $sa1_samples,
+              sa2_path             => $sa2_path,
+              sa2_options          => $sa2_options,
+              sa2_minute           => $sa2_minute,
+              sa2_hour             => $sa2_hour,
+              generate_summary     => $generate_summary,
+          }),
         }
       }
 
@@ -123,6 +189,7 @@ class sysstat (
             sa_umask        => $sa_umask,
             zip             => $zip,
         }),
+        require => Package[$package],
       }
 
       file { $sa_dir:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,59 +49,59 @@ class sysstat (
   case $facts['os']['family'] {
     'AIX': {
       cron { 'sa1_path_weekday':
-              ensure  => 'absent',
-              command => "${sa1_path} 1200 3 &",
-              user    => 'adm',
-              hour    => ['8-17'],
-              minute  => [0],
-              weekday => ['1-5'],
+        ensure  => 'absent',
+        command => "${sa1_path} 1200 3 &",
+        user    => 'adm',
+        hour    => ['8-17'],
+        minute  => [0],
+        weekday => ['1-5'],
       }
       cron { 'sa1_path_weekday_after_hours':
-              ensure  => 'absent',
-              command => "${sa1_path} &",
-              user    => 'adm',
-              minute  => [0],
-              hour    => ['18-7'],
-              weekday => ['1-5'],
+        ensure  => 'absent',
+        command => "${sa1_path} &",
+        user    => 'adm',
+        minute  => [0],
+        hour    => ['18-7'],
+        weekday => ['1-5'],
       }
       cron { 'sa1_path_weekend':
-              ensure  => 'absent',
-              command => "${sa1_path} &",
-              user    => 'adm',
-              minute  => [0],
-              weekday => [0,6],
+        ensure  => 'absent',
+        command => "${sa1_path} &",
+        user    => 'adm',
+        minute  => [0],
+        weekday => [0,6],
       }
       cron { 'sa2_path_weekday_after_hours':
-              ensure  => $cron_ensure,
-              command => "${sa2_path} -s 8:00 -e 18:01 -i 3600 -ubcwyaqvm &",
-              user    => 'adm',
-              minute  => [5],
-              hour    => [18],
-              weekday => ['1-5'],
+        ensure  => $cron_ensure,
+        command => "${sa2_path} -s 8:00 -e 18:01 -i 3600 -ubcwyaqvm &",
+        user    => 'adm',
+        minute  => [5],
+        hour    => [18],
+        weekday => ['1-5'],
       }
       cron { 'sa1_daily_5_mins':
-              ensure  => $cron_ensure,
-              command => "${sa1_path} &",
-              user    => 'adm',
-              minute  => [0,5,10,15,20,25,30,35,40,45,50,55],
-              weekday => ['0-6'],
+        ensure  => $cron_ensure,
+        command => "${sa1_path} &",
+        user    => 'adm',
+        minute  => [0,5,10,15,20,25,30,35,40,45,50,55],
+        weekday => ['0-6'],
       }
     }
     default: {
       file { $cron_path:
         ensure  => $file_ensure,
         content => epp('sysstat/crontab.epp', {
-          sa1_path             => $sa1_path,
-          sa1_options          => $sa1_options,
-          sa1_interval         => $sa1_interval,
-          sa1_duration         => $sa1_duration,
-          sa1_duration_seconds => $sa1_duration_seconds,
-          sa1_samples          => $sa1_samples,
-          sa2_path             => $sa2_path,
-          sa2_options          => $sa2_options,
-          sa2_minute           => $sa2_minute,
-          sa2_hour             => $sa2_hour,
-          generate_summary     => $generate_summary,
+            sa1_path             => $sa1_path,
+            sa1_options          => $sa1_options,
+            sa1_interval         => $sa1_interval,
+            sa1_duration         => $sa1_duration,
+            sa1_duration_seconds => $sa1_duration_seconds,
+            sa1_samples          => $sa1_samples,
+            sa2_path             => $sa2_path,
+            sa2_options          => $sa2_options,
+            sa2_minute           => $sa2_minute,
+            sa2_hour             => $sa2_hour,
+            generate_summary     => $generate_summary,
         }),
       }
 
@@ -111,16 +111,17 @@ class sysstat (
           before => File[$conf_path],
         }
       }
+
       file { $conf_path:
         ensure  => file,
         content => epp('sysstat/sysconfig.epp', {
-          history         => $history,
-          compressafter   => $compressafter,
-          sa_dir          => $sa_dir,
-          sa2_delay_range => $sa2_delay_range,
-          sadc_options    => $sadc_options,
-          sa_umask        => $sa_umask,
-          zip             => $zip,
+            history         => $history,
+            compressafter   => $compressafter,
+            sa_dir          => $sa_dir,
+            sa2_delay_range => $sa2_delay_range,
+            sadc_options    => $sadc_options,
+            sa_umask        => $sa_umask,
+            zip             => $zip,
         }),
       }
 
@@ -130,7 +131,7 @@ class sysstat (
         group  => 'root',
       }
 
-      # With this module we disable the Debian uniqueness regardless of whether 
+      # With this module we disable the Debian uniqueness regardless of whether
       # the module is disabled or not
       if $facts['os']['family'] == 'Debian' {
         service { 'sysstat':

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "qtechnologies-sysstat",
-  "version": "1.2.8",
+  "version": "2.0.0",
   "author": "Q-Technologies",
   "summary": " Puppet module to manage the installation and configuration of Sysstat on various OSes",
   "license": "Apache-2.0",
@@ -24,28 +24,37 @@
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "6.0",
-        "7.0"
+        "7.0",
+        "8.0",
+        "9.0"
       ]
     },
     {
       "operatingsystem": "Centos",
       "operatingsystemrelease": [
         "6.0",
-        "7.0"
+        "7.0",
+        "8.0",
+        "9.0"
       ]
     },
     {
       "operatingsystem": "OEL",
       "operatingsystemrelease": [
         "6.0",
-        "7.0"
+        "7.0",
+        "8.0",
+        "9.0"
       ]
     },
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "7.0",
-        "8.0"
+        "8.0",
+        "9.0",
+        "10.0",
+        "11.0"
       ]
     },
     {
@@ -53,7 +62,11 @@
       "operatingsystemrelease": [
         "12.04",
         "14.04",
-        "16.04"
+        "16.04",
+        "18.04",
+        "20.04",
+        "22.04",
+        "24.04"
       ]
     },
     {

--- a/templates/sysstat_collect.service.override.epp
+++ b/templates/sysstat_collect.service.override.epp
@@ -1,0 +1,2 @@
+[Service]
+ExecStart=<%= $sa1_path %> <%= $sa1_duration_seconds %> <%= $sa1_samples %>

--- a/templates/sysstat_collect.timer.override.epp
+++ b/templates/sysstat_collect.timer.override.epp
@@ -1,0 +1,5 @@
+[Unit]
+Description=Run system activity accounting tool every <%= $sa1_interval %> minutes
+
+[Timer]
+OnCalendar=*:00/<%= $sa1_interval %>

--- a/templates/sysstat_summary.service.override.epp
+++ b/templates/sysstat_summary.service.override.epp
@@ -1,0 +1,2 @@
+[Service]
+ExecStart=<%= $sa2_path %> <%= $sa2_options %>

--- a/templates/sysstat_summary.timer.override.epp
+++ b/templates/sysstat_summary.timer.override.epp
@@ -1,0 +1,5 @@
+[Unit]
+Description=Generate summary of yesterday's process accounting
+
+[Timer]
+OnCalendar=00:<%= $sa2_hour %>:<%= $sa2_minute %>


### PR DESCRIPTION
Summary of changes:
- Fix format (whitespace changes) 
- Always install the sysstat package
  - Systemd services are provided by the package
- Bump version to 2.0.0
  - Because removed installpkg var
- Use systemd services if available otherwise fallback to cron jobs