### PR TITLE
Fix OnCalendar Expression for sysstat summary

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "qtechnologies-sysstat",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "Q-Technologies",
   "summary": " Puppet module to manage the installation and configuration of Sysstat on various OSes",
   "license": "Apache-2.0",

--- a/templates/sysstat_summary.timer.override.epp
+++ b/templates/sysstat_summary.timer.override.epp
@@ -2,4 +2,4 @@
 Description=Generate summary of yesterday's process accounting
 
 [Timer]
-OnCalendar=00:<%= $sa2_hour %>:<%= $sa2_minute %>
+OnCalendar=<%= $sa2_hour %>:<%= $sa2_minute %>


### PR DESCRIPTION
# Summary of Changes

- Fix the [OnCalendar expression](https://wiki.archlinux.org/title/Systemd/Timers#Realtime_timer)
- Bump the micro version

Close #16 